### PR TITLE
Fix speaker filter when semantic_search uses string selector

### DIFF
--- a/app.py
+++ b/app.py
@@ -269,8 +269,12 @@ def semantic_search(query: str, selected_speakers: Union[List[str], str], top_k:
                 continue
             
             if selected_speakers and selected_speakers != 'all':
-                if isinstance(selected_speakers, list) and speaker not in selected_speakers:
-                    continue
+                if isinstance(selected_speakers, list):
+                    if speaker not in selected_speakers:
+                        continue
+                elif isinstance(selected_speakers, str):
+                    if speaker != selected_speakers:
+                        continue
             
             item_embedding = np.array(item.get('embedding', []))
             if len(item_embedding) == 0:


### PR DESCRIPTION
## Summary
- handle string speaker filter in `semantic_search`

## Testing
- `python test_semantic.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689c6296cd98832f995dc759c91aab31